### PR TITLE
188171533: change update to update_one for py311 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
 setup(
     python_requires=">=3.6",
     name="diagnose",
-    version="5.0.0",
+    version="5.0.1",
     author="Robert Brewer",
     author_email="dev@crunch.io",
     description="A library for instrumenting Python code at runtime.",

--- a/src/diagnose/managers.py
+++ b/src/diagnose/managers.py
@@ -132,7 +132,7 @@ class InstrumentManager:
         self.period = period
         if self.apply_thread is None:
             self.apply_thread = t = threading.Thread(target=self._cycle)
-            t.setName("diagnose.manager.apply_in_background")
+            t.name = "diagnose.manager.apply_in_background"
             t.daemon = True
             t.start()
 

--- a/src/diagnose/managers.py
+++ b/src/diagnose/managers.py
@@ -212,7 +212,7 @@ class MongoDBInstrumentManager(InstrumentManager):
             newval = {"lm": doc["lastmodified"], "err": error}
             if doc["applied"].get(self.process_id, {}) != newval:
                 doc["applied"][self.process_id] = newval
-                self.collection.update(
+                self.collection.update_one(
                     {self.id_field: id},
                     {
                         "$set": {


### PR DESCRIPTION
https://pymongo.readthedocs.io/en/stable/migrate-to-pymongo4.html#collection-update-is-removed
Removing the deprecated pymongo call `update` because it will fail when we move to python 3.11.

Sentry errors related:
- https://crunch-io.slack.com/archives/C4V5Z2U82/p1725869736113739
- https://crunch-io.slack.com/archives/C4V5Z2U82/p1725869736131169
